### PR TITLE
Import of generator_pb2 in Jupyter Notebook of Chapter 02

### DIFF
--- a/Chapter02/notebook.ipynb
+++ b/Chapter02/notebook.ipynb
@@ -192,6 +192,7 @@
     }
    ],
    "source": [
+    "from magenta.protobuf import generator_pb2\n",
     "# The generator interface is common for all models\n",
     "generator_options = generator_pb2.GeneratorOptions()\n",
     "\n",

--- a/Chapter02/notebook.ipynb
+++ b/Chapter02/notebook.ipynb
@@ -193,6 +193,7 @@
    ],
    "source": [
     "from magenta.protobuf import generator_pb2\n",
+    "\n",
     "# The generator interface is common for all models\n",
     "generator_options = generator_pb2.GeneratorOptions()\n",
     "\n",


### PR DESCRIPTION
The import of generator_pb2 is present in the Python file, but missing from the Notebook